### PR TITLE
:memo: add build instructions for fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ For example, you try the following prompt:
 cargo run --release -- -m /data/Llama/LLaMA/7B/ggml-model-q4_0.bin -p "Tell me how cool the Rust programming language is
 ```
 
+### Fedora
+
+On Fedora, to avoid build errors due to the missing `stddef.h` file, you may need to install the following packages:
+
+``` shell
+sudo dnf groupinstall "Development Tools" "Development Libraries"
+```
+
+Then build with `CPATH` set to the location of the `gcc` headers :
+      
+``` shell
+CPATH="/usr/lib/gcc/x86_64-redhat-linux/12/include/" cargo build --release
+```
+
+
 ## Q&A
 
 - **Q: Why did you do this?**


### PR DESCRIPTION
Closes #22

## How to test it ?

`docker run -it fedora bash`

Then

```bash
ls /usr/lib/        #no gcc
dnf groupinstall "Development Tools" "Development Libraries"
ls /usr/lib/gcc/x86_64-redhat-linux/12/include/        #installed
git clone https://github.com/sylvain-reynaud/llama-rs
cd llama-rs/
curl https://sh.rustup.rs -sSf | sh
source "$HOME/.cargo/env"
cargo build --release        #still fails
CPATH="/usr/lib/gcc/x86_64-redhat-linux/12/include/" cargo build --release        #success
```