### PR TITLE
Add --float16 (was --float-16) to llama-cli and associated support to llama-rs

### DIFF
--- a/llama-cli/src/cli_args.rs
+++ b/llama-cli/src/cli_args.rs
@@ -81,7 +81,7 @@ pub struct Args {
     /// Use 16-bit floats for model memory key and value. Ignored when restoring
     /// from the cache.
     #[arg(long, default_value_t = false)]
-    pub float_16: bool,
+    pub float16: bool,
 }
 
 /// CLI args are stored in a lazy static variable so they're accessible from

--- a/llama-cli/src/cli_args.rs
+++ b/llama-cli/src/cli_args.rs
@@ -77,6 +77,11 @@ pub struct Args {
     /// machines.
     #[arg(long, default_value = None)]
     pub seed: Option<u64>,
+
+    /// Use 16-bit floats for model memory key and value. Ignored when restoring
+    /// from the cache.
+    #[arg(long, default_value_t = false)]
+    pub float_16: bool,
 }
 
 /// CLI args are stored in a lazy static variable so they're accessible from

--- a/llama-cli/src/main.rs
+++ b/llama-cli/src/main.rs
@@ -1,8 +1,10 @@
 use std::{convert::Infallible, io::Write};
 
 use cli_args::CLI_ARGS;
-use llama_rs::{InferenceError, InferenceParameters, InferenceSnapshot};
-use llama_rs::{InferenceSessionParameters, ModelKVMemoryType};
+use llama_rs::{
+    InferenceError, InferenceParameters, InferenceSessionParameters, InferenceSnapshot,
+    ModelKVMemoryType,
+};
 use rand::thread_rng;
 use rand::SeedableRng;
 use rustyline::error::ReadlineError;
@@ -79,7 +81,7 @@ fn main() {
         temp: args.temp,
     };
     let inference_session_params = {
-        let mem_typ = if args.float_16 {
+        let mem_typ = if args.float16 {
             ModelKVMemoryType::Float16
         } else {
             ModelKVMemoryType::Float32


### PR DESCRIPTION
This change adds a `--float-16` flag which allows using a 16 bit float for the model memory key and value tensors. 

The `--float-16` flag enables it for both K and V, however internally it is possible to set it independently (I don't know why you'd want to, but...)

In addition to saving memory, this change only reduces the size of the cached prompt by about 50% when enabled.

Should complete #51.