### PR TITLE
Support latest (breaking) changes to GGML file format

### DIFF
--- a/llama-rs/src/ggml.rs
+++ b/llama-rs/src/ggml.rs
@@ -6,6 +6,11 @@ use std::{
 
 pub use ggml_raw::ggml_type as Type;
 
+pub const FILE_MAGIC: i32 = 0x67676d66;
+pub const FILE_MAGIC_UNVERSIONED: i32 = 0x67676d6c;
+
+pub const FORMAT_VERSION: u32 = 1;
+
 pub const TYPE_Q4_0: ggml_raw::ggml_type = ggml_raw::GGML_TYPE_Q4_0;
 pub const TYPE_Q4_1: ggml_raw::ggml_type = ggml_raw::GGML_TYPE_Q4_1;
 pub const TYPE_I32: ggml_raw::ggml_type = ggml_raw::GGML_TYPE_I32;

--- a/llama-rs/src/lib.rs
+++ b/llama-rs/src/lib.rs
@@ -385,15 +385,15 @@ impl Model {
         }
 
         fn read_i32(reader: &mut impl BufRead) -> Result<i32, LoadError> {
-            return Ok(i32::from_le_bytes(read_bytes::<4>(reader)?));
+            Ok(i32::from_le_bytes(read_bytes::<4>(reader)?))
         }
 
         fn read_u32(reader: &mut impl BufRead) -> Result<u32, LoadError> {
-            return Ok(u32::from_le_bytes(read_bytes::<4>(reader)?));
+            Ok(u32::from_le_bytes(read_bytes::<4>(reader)?))
         }
 
         fn read_f32(reader: &mut impl BufRead) -> Result<f32, LoadError> {
-            return Ok(f32::from_le_bytes(read_bytes::<4>(reader)?));
+            Ok(f32::from_le_bytes(read_bytes::<4>(reader)?))
         }
 
         /// Helper function. Reads a string from the buffer and returns it.

--- a/llama-rs/src/lib.rs
+++ b/llama-rs/src/lib.rs
@@ -377,7 +377,10 @@ impl Model {
             let mut bytes = [0u8; N];
             reader
                 .read_exact(&mut bytes)
-                .map_err(|e| LoadError::ReadExactFailed { source: e, bytes: N })?;
+                .map_err(|e| LoadError::ReadExactFailed {
+                    source: e,
+                    bytes: N,
+                })?;
             Ok(bytes)
         }
 
@@ -410,7 +413,11 @@ impl Model {
         let is_legacy_model: bool = match read_i32(&mut reader)? {
             ggml::FILE_MAGIC => false,
             ggml::FILE_MAGIC_UNVERSIONED => true,
-            _ => return Err(LoadError::InvalidMagic { path: main_path.to_owned() }),
+            _ => {
+                return Err(LoadError::InvalidMagic {
+                    path: main_path.to_owned(),
+                })
+            }
         };
 
         // Load format version


### PR DESCRIPTION
Latest ggml models have:
- Different magic
- A format version
- Scores for tokens (currently parsed but unused)

This PR maintains support for older ('legacy') models
A model downloaded and converted on latest master in `llama.cpp` now works with `llama-rs` but the output seems qualitatively worse. Haven't played around much with `llama-rs` though so it's hard to say whether this is a regression.