### PR TITLE
Add --bias-tokens and --dump-prompt-tokens flags and associated backend changes.

### DIFF
--- a/llama-cli/src/cli_args.rs
+++ b/llama-cli/src/cli_args.rs
@@ -91,7 +91,13 @@ pub struct Args {
     /// (start of document) and 2 (end of document) to -1.0 which effectively
     /// disables the model from generating responses containing those token IDs.
     #[arg(long, default_value = None, value_parser = parse_bias)]
-    pub bias_tokens: Option<TokenBias>,
+    pub token_bias: Option<TokenBias>,
+
+    /// Prevent the end of stream (EOS/EOD) token from being generated. This will allow the
+    /// model to generate text until it runs out of context space. Note: The --token-bias
+    /// option will override this if specified.
+    #[arg(long, default_value_t = false)]
+    pub ignore_eos: bool,
 
     /// Dumps the prompt to console and exits, first as a comma seperated list of token IDs
     /// and then as a list of comma seperated string keys and token ID values.

--- a/llama-cli/src/cli_args.rs
+++ b/llama-cli/src/cli_args.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use llama_rs::TokenBias;
 use once_cell::sync::Lazy;
 
 #[derive(Parser, Debug)]
@@ -82,6 +83,24 @@ pub struct Args {
     /// from the cache.
     #[arg(long, default_value_t = false)]
     pub float16: bool,
+
+    /// A comma separated list of token biases. The list should be in the format
+    /// "TID=BIAS,TID=BIAS" where TID is an integer token ID and BIAS is a
+    /// floating point number.
+    /// For example, "1=-1.0,2=-1.0" sets the bias for token IDs 1
+    /// (start of document) and 2 (end of document) to -1.0 which effectively
+    /// disables the model from generating responses containing those token IDs.
+    #[arg(long, default_value = None, value_parser = parse_bias)]
+    pub bias_tokens: Option<TokenBias>,
+
+    /// Dumps the prompt to console and exits, first as a comma seperated list of token IDs
+    /// and then as a list of comma seperated string keys and token ID values.
+    #[arg(long, default_value_t = false)]
+    pub dump_prompt_tokens: bool,
+}
+
+fn parse_bias(s: &str) -> Result<TokenBias, String> {
+    s.parse()
 }
 
 /// CLI args are stored in a lazy static variable so they're accessible from

--- a/llama-cli/src/main.rs
+++ b/llama-cli/src/main.rs
@@ -3,7 +3,7 @@ use std::{convert::Infallible, io::Write};
 use cli_args::CLI_ARGS;
 use llama_rs::{
     InferenceError, InferenceParameters, InferenceSessionParameters, InferenceSnapshot,
-    ModelKVMemoryType, Vocabulary,
+    ModelKVMemoryType, TokenBias, Vocabulary, EOD_TOKEN_ID,
 };
 use rand::thread_rng;
 use rand::SeedableRng;
@@ -105,7 +105,13 @@ fn main() {
         top_p: args.top_p,
         repeat_penalty: args.repeat_penalty,
         temp: args.temp,
-        bias_tokens: args.bias_tokens.clone().unwrap_or_default(),
+        bias_tokens: args.token_bias.clone().unwrap_or_else(|| {
+            if args.ignore_eos {
+                TokenBias::new(vec![(EOD_TOKEN_ID, -1.0)])
+            } else {
+                TokenBias::default()
+            }
+        }),
     };
     let inference_session_params = {
         let mem_typ = if args.float16 {

--- a/llama-rs/src/lib.rs
+++ b/llama-rs/src/lib.rs
@@ -14,6 +14,8 @@ use thiserror::Error;
 use partial_sort::PartialSort;
 use rand::{distributions::WeightedIndex, prelude::Distribution};
 
+pub const EOD_TOKEN_ID: TokenId = 2; // Hardcoded (for now?)
+
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Hyperparameters {
     n_vocab: i32,
@@ -1361,11 +1363,11 @@ impl InferenceSession {
         model.evaluate(self, params.n_threads, &[next_token]);
 
         // Return the next token
-        if next_token == 2 {
-            Ok(OutputToken::EndOfText)
+        Ok(if next_token as TokenId == EOD_TOKEN_ID {
+            OutputToken::EndOfText
         } else {
-            Ok(OutputToken::Token(&vocab.id_to_token[next_token as usize]))
-        }
+            OutputToken::Token(&vocab.id_to_token[next_token as usize])
+        })
     }
 
     // todo: see if we can reduce the arguments here somehow - consolidate model and vocab maybe?


### PR DESCRIPTION
`--bias-tokens` allows passing a list of token ids and float point biases. This can be used to emulate llama.cpp's `--ignore-eos` feature in a more flexible way. For example using `--bias-tokens 2=-1` will prevent the EOD token from being generated and the model will just ramble on until it hits the context limit.

`--dump-prompt-tokens` will just dump the tokens for the prompt after loading, in two formats: First just as a list of token ids and then as a list with the associated string the token came from. For example, with prompt `What a kerfuffle!`, you'd get the output:

    === Dumping prompt tokens:
    5618, 263, 13023, 21154, 600, 280, 29991
    "What":5618, " a":263, " ker":13023, "fu":21154, "ff":600, "le":280, "!":29991

***

Some minor backend changes were necessary to make this possible but the behavior of the existing code should remain unchanged. One thing I did do was move the `tokenize` method to `Vocabulary` and changed it to return `Vec<(&str, TokenId)>`. The `tokenize` method in the session remains as a wrapper to that which just strips out the string part.