### PR TITLE
fix 65B model 

### DIFF
--- a/llama-rs/src/lib.rs
+++ b/llama-rs/src/lib.rs
@@ -1085,6 +1085,8 @@ impl Model {
             f16_: _,
         } = self.hparams;
 
+        // For the first run, we need to guess a maximum buffer size so we can measure
+        // the actual memory consumption of the temporary ggml context.
         let mut buf_size = 1024 * 1024 * 1024;
         if session.mem_per_token > 0 && session.mem_per_token * n > buf_size {
             // add 10% to account for ggml object overhead

--- a/llama-rs/src/lib.rs
+++ b/llama-rs/src/lib.rs
@@ -147,6 +147,7 @@ type Token = String;
 pub struct Vocabulary {
     /// Maps every integer (index) token id to its corresponding string
     mapping: Vec<Token>,
+    score: Vec<f32>,
 }
 
 #[derive(serde::Serialize)]
@@ -253,8 +254,12 @@ pub enum LoadError {
     #[error("invalid integer conversion")]
     InvalidIntegerConversion(#[from] std::num::TryFromIntError),
 
+    #[error("file is pre-versioned, generate another please! at {path:?}")]
+    PreVersioned { path: PathBuf },
     #[error("invalid magic number for {path:?}")]
     InvalidMagic { path: PathBuf },
+    #[error("invalid version number for {path:?}")]
+    InvalidVersion { path: PathBuf },
     #[error("invalid value {value} for `f16` in hyperparameters")]
     HyperparametersF16Invalid { value: i32 },
     #[error("unknown tensor `{tensor_name}` in {path:?}")]
@@ -344,8 +349,24 @@ impl Model {
         // Verify magic
         {
             let magic = read_i32(&mut reader)?;
-            if magic != 0x67676d6c {
+            if magic == 0x67676d6c {
+                return Err(LoadError::PreVersioned {
+                    path: main_path.to_owned(),
+                });
+            }
+
+            if magic != 0x67676d66 {
                 return Err(LoadError::InvalidMagic {
+                    path: main_path.to_owned(),
+                });
+            }
+        }
+
+        // Verify the version
+        {
+            let format_version = read_i32(&mut reader)?;
+            if format_version != 1 {
+                return Err(LoadError::InvalidVersion {
                     path: main_path.to_owned(),
                 });
             }
@@ -373,9 +394,7 @@ impl Model {
 
         load_progress_callback(LoadProgress::HyperparametersLoaded(&hparams));
 
-        // ===============
         // Load vocabulary
-        // ===============
         let mut vocab = Vocabulary::default();
         for i in 0..hparams.n_vocab {
             let len = read_i32(&mut reader)?;
@@ -387,8 +406,10 @@ impl Model {
                 });
                 vocab.mapping.push("�".to_string());
             }
-        }
 
+            let score: f32 = read_i32(&mut reader)? as f32;
+            vocab.score.push(score);
+        }
         // for the big tensors, we have the option to store the data in 16-bit
         // floats or quantized in order to save memory and also to speed up the
         // computation

--- a/llama-rs/src/lib.rs
+++ b/llama-rs/src/lib.rs
@@ -932,7 +932,7 @@ impl Model {
             f16_: _,
         } = self.hparams;
 
-        let mut buf_size = 512 * 1024 * 1024;
+        let mut buf_size = 1024 * 1024 * 1024;
         if session.mem_per_token > 0 && session.mem_per_token * n > buf_size {
             // add 10% to account for ggml object overhead
             buf_size = (1.1f64 * session.mem_per_token as f64 * n as f64) as usize;


### PR DESCRIPTION
Import fixes for magic (https://github.com/setzer22/llama-rs/issues/59#issuecomment-1479910799). 

Fix 65B model error (https://github.com/setzer22/llama-rs/issues/65).

A better fix for the memory allocation issue is probably possible, but this works without any impact on memory for any model (tested 7B: 4G, 13B: 5G, 30B: 20G, 65B: 39G). 