### PR TITLE
Strip off last \r\n in the prompt file.

### DIFF
--- a/llama-cli/src/main.rs
+++ b/llama-cli/src/main.rs
@@ -128,7 +128,19 @@ fn main() {
 
     let prompt = if let Some(path) = &args.prompt_file {
         match std::fs::read_to_string(path) {
-            Ok(prompt) => prompt,
+            Ok(mut prompt) => {
+                // Strip off the last character if it's exactly newline. Also strip off a single
+                // carriage return if it's there. Since String must be valid UTF-8 it should be
+                // guaranteed that looking at the string as bytes here is safe: UTF-8 non-ASCII
+                // bytes will always the high bit set.
+                if matches!(prompt.as_bytes().last(), Some(b'\n')) {
+                    prompt.pop();
+                }
+                if matches!(prompt.as_bytes().last(), Some(b'\r')) {
+                    prompt.pop();
+                }
+                prompt
+            }
             Err(err) => {
                 log::error!("Could not read prompt file at {path}. Error {err}");
                 std::process::exit(1);


### PR DESCRIPTION
Naturally also works if it's just `\r` or just `\n`. (However `\n\r` would result in `\n`. If you put weird stuff like that in your prompt file, you deserve what you get.)

Closes #60