### PR TITLE
WIP: Convert `pth` to `ggml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +16,12 @@ checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bincode"
@@ -31,6 +43,12 @@ name = "bytemuck"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
@@ -72,7 +90,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -96,6 +114,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "csv"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b015497079b9a9d69c02ad25de6c0a6edef051ea6360a327d0bd05802ef64ad"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +197,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "endian-type"
@@ -196,6 +284,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96282e96bfcd3da0d3aa9938bedf1e50df3269b6db08b4876d2da0bb1a0841cf"
+dependencies = [
+ "ahash",
+ "autocfg",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,6 +341,27 @@ dependencies = [
  "rustix",
  "windows-sys",
 ]
+
+[[package]]
+name = "iter-read"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c397ca3ea05ad509c4ec451fea28b4771236a376ca1c69fd5143aae0cf8f93c4"
+
+[[package]]
+name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "jobserver"
@@ -295,9 +414,13 @@ dependencies = [
  "bytemuck",
  "ggml-raw",
  "partial_sort",
+ "protobuf",
  "rand",
+ "rust_tokenizers",
  "serde",
+ "serde-pickle",
  "serde_bytes",
+ "serde_json",
  "thiserror",
 ]
 
@@ -323,6 +446,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +473,36 @@ dependencies = [
  "cfg-if",
  "libc",
  "static_assertions",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -392,7 +554,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -415,6 +577,12 @@ checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e86d370532557ae7573551a1ec8235a0f8d6cb276c7c9e6aa490b511c447485"
 
 [[package]]
 name = "quote"
@@ -466,6 +634,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,6 +691,25 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "rust_tokenizers"
+version = "3.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c4313059ea8764ff2743ffaaa42fba0e4d5f8ff12febe4f3c74d598f629f62"
+dependencies = [
+ "csv",
+ "hashbrown",
+ "itertools",
+ "lazy_static",
+ "protobuf",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "unicode-normalization",
+ "unicode-normalization-alignments",
+]
 
 [[package]]
 name = "rustix"
@@ -546,6 +755,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,11 +768,24 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.156"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
+checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-pickle"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762ad136a26407c6a80825813600ceeab5e613660d93d79a41f0ec877171e71"
+dependencies = [
+ "byteorder",
+ "iter-read",
+ "num-bigint",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -571,13 +799,24 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.156"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
+checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.10",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -634,7 +873,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -642,6 +881,17 @@ name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -674,14 +924,47 @@ checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "unicode-ident"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "unicode-segmentation"

--- a/llama-cli/src/cli_args.rs
+++ b/llama-cli/src/cli_args.rs
@@ -6,7 +6,27 @@ use once_cell::sync::Lazy;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
-pub struct Args {
+pub enum Args {
+    #[command(name = "generate")]
+    Generate(Generate),
+
+    #[command(name = "convert")]
+    Convert(Convert),
+}
+
+#[derive(Parser, Debug)]
+pub struct Convert {
+    /// Path to model directory
+    #[arg(long, short = 'd')]
+    pub dir: String,
+
+    /// File type to convert to
+    #[arg(long, default_value_t = false)]
+    pub f32: bool,
+}
+
+#[derive(Parser, Debug)]
+pub struct Generate {
     /// Where to load the model path from
     #[arg(long, short = 'm')]
     pub model_path: String,

--- a/llama-rs/Cargo.toml
+++ b/llama-rs/Cargo.toml
@@ -16,3 +16,7 @@ rand = { workspace = true }
 serde = { version = "1.0.156", features = ["derive"] }
 serde_bytes = "0.11"
 bincode = "1.3.3"
+serde_json = "1.0.94"
+serde-pickle = "1.1.1"
+protobuf = "= 2.14.0"
+rust_tokenizers = "3.1.2"

--- a/llama-rs/src/convert.rs
+++ b/llama-rs/src/convert.rs
@@ -1,0 +1,153 @@
+use rust_tokenizers::preprocessing::vocab::sentencepiece_proto::sentencepiece_model::ModelProto;
+use serde::Deserialize;
+use std::{
+    borrow::BorrowMut,
+    collections::HashMap,
+    fs::{read_to_string, File},
+    io::{Read, Write},
+    path::Path,
+    vec,
+};
+
+use crate::{Hyperparameters, Vocabulary};
+
+impl From<&Path> for Vocabulary {
+    fn from(path: &Path) -> Self {
+        let mut f = File::open(path).unwrap();
+        let mut contents = Vec::new();
+        f.read_to_end(&mut contents).unwrap();
+
+        let proto = protobuf::parse_from_bytes::<ModelProto>(contents.as_slice()).unwrap();
+        let mut id_to_token = vec![];
+        let mut id_to_token_score = vec![];
+        let mut token_to_id = HashMap::new();
+        let mut max_token_length = 0;
+
+        for (idx, piece) in proto.get_pieces().iter().enumerate() {
+            let word = piece.get_piece().to_string();
+            max_token_length = max_token_length.max(word.len());
+            id_to_token.push(word.clone());
+            token_to_id.insert(word, idx as i32);
+            id_to_token_score.push(piece.get_score());
+        }
+        Vocabulary {
+            id_to_token: id_to_token,
+            id_to_token_score: id_to_token_score,
+            token_to_id: token_to_id,
+            max_token_length: max_token_length,
+        }
+    }
+}
+
+fn get_n_parts(dim: i32) -> usize {
+    match dim {
+        4096 => 1,
+        5120 => 2,
+        6656 => 4,
+        8192 => 8,
+        _ => panic!("Invalid dimension"),
+    }
+}
+fn get_f_type(f32: bool) -> String {
+    match f32 {
+        true => "f32",
+        false => "f16",
+    }
+    .to_string()
+}
+
+#[derive(Deserialize)]
+struct HParams {
+    dim: i32,
+    multiple_of: i32,
+    n_heads: i32,
+    n_layers: i32,
+    vocab_size: i32,
+}
+
+fn load_hyperparams(path: &Path, f32: bool, vocab: &Vocabulary) -> Hyperparameters {
+    let json = read_to_string(path.join("params.json")).expect("Unable to read file");
+    let hparams: HParams = serde_json::from_str(&json).expect("Unable to parse json");
+    Hyperparameters {
+        f16_: match f32 {
+            true => 0,
+            false => 1,
+        },
+        n_ctx: 0,
+        n_embd: hparams.dim,
+        n_head: hparams.n_heads,
+        n_layer: hparams.n_layers,
+        n_vocab: match hparams.vocab_size {
+            -1 => vocab.id_to_token.len() as i32,
+            _ => hparams.vocab_size as i32,
+        },
+        n_mult: hparams.multiple_of,
+        n_rot: hparams.dim / hparams.n_heads,
+    }
+}
+
+fn write_header(fout: &mut File, hparams: &Hyperparameters) -> Result<(), String> {
+    let values = vec![
+        0x67676d66, // magic: ggmf in hex
+        1,          // file version
+        hparams.n_vocab,
+        hparams.n_embd,
+        hparams.n_mult,
+        hparams.n_head,
+        hparams.n_layer,
+        hparams.n_embd / hparams.n_head,
+        hparams.f16_,
+    ];
+    let mut packed_values: Vec<u8> = vec![];
+
+    for value in values {
+        packed_values.extend(&value.to_le_bytes());
+    }
+
+    fout.write_all(&packed_values)
+        .expect("Unable to write headers to the file.");
+
+    Ok(())
+}
+
+fn write_tokens(file: &mut File, vocab: &Vocabulary) -> Result<(), String> {
+    let mut values: Vec<u8> = vec![];
+    for (i, token) in vocab.id_to_token.iter().enumerate() {
+        let text = match token {
+            _ if token.contains("<unk>") => " \u{2047} ".as_bytes().to_vec(),
+            _ if token.contains("s>") => vec![],
+            _ if token.len() == 6 && token.contains("<0x") => {
+                vec![u8::from_str_radix(&token[3..5], 16).unwrap()]
+            }
+            _ => token.replace("\u{2581}", " ").as_bytes().to_vec(),
+        };
+        values.extend((text.len() as i32).to_le_bytes());
+        values.extend(&text);
+        values.extend(vocab.id_to_token_score[i].to_le_bytes());
+    }
+
+    file.write_all(&values)
+        .expect("Unable to write headers to the file.");
+
+    Ok(())
+}
+
+pub fn convert_pth_to_ggml(dir: &String, f32: bool) {
+    let path = Path::new(dir);
+
+    let tokenizer_path = path.parent().unwrap().join("tokenizer.model");
+    let vocab = Vocabulary::from(tokenizer_path.as_path());
+
+    let hparams = load_hyperparams(path, f32, &vocab);
+    let n_parts = get_n_parts(hparams.n_embd);
+
+    for i in 0..n_parts {
+        let fname_out = path.join(format!("rust-model-{}.bin", get_f_type(f32)));
+        let mut file = File::create(fname_out).expect("Unable to create file");
+        write_header(file.borrow_mut(), &hparams).unwrap();
+        write_tokens(file.borrow_mut(), &vocab).unwrap();
+
+        let _fname_model = path.join(format!("consolidated.0{}.pth", i));
+        // Todo process and write variables
+    }
+}

--- a/llama-rs/src/lib.rs
+++ b/llama-rs/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod convert;
 mod ggml;
 
 use core::slice;
@@ -10,6 +11,7 @@ use std::{
     time,
 };
 
+use serde::Deserialize;
 use thiserror::Error;
 
 use partial_sort::PartialSort;
@@ -17,7 +19,7 @@ use rand::{distributions::WeightedIndex, prelude::Distribution};
 
 pub const EOD_TOKEN_ID: TokenId = 2; // Hardcoded (for now?)
 
-#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
 pub struct Hyperparameters {
     n_vocab: i32,
     n_ctx: i32,


### PR DESCRIPTION
I'm still working on adding the weights to the file, rn it only adds params and tokens to the file (the md5 hash matches the llama.cpp generated file without the weights). And also no quantizing.
Also added `generate` and `convert` subcommands to the cli as well.
Let me know if anything needs changing 🙂

Resolves https://github.com/rustformers/llama-rs/issues/21