### PR TITLE
Implemented `quantize.cpp`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,6 +199,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +296,7 @@ dependencies = [
  "bincode",
  "bytemuck",
  "ggml-raw",
+ "half",
  "partial_sort",
  "rand",
  "serde",

--- a/ggml-raw/ggml/ggml.c
+++ b/ggml-raw/ggml/ggml.c
@@ -397,6 +397,53 @@ static inline __m128i packNibbles( __m256i bytes )
 }
 #endif
 
+// method 5
+// blocks of QK elements
+// represented with a single float (delta) and QK/2 8-bit ints (i.e QK 4-bit signed integer factors)
+
+// reference implementation for deterministic creation of model files
+static void quantize_row_q4_0_reference(const float * restrict x, void * restrict y, int k) {
+    assert(k % QK == 0);
+    const int nb = k / QK;
+
+    const size_t bs = sizeof(float) + QK/2;
+
+    uint8_t * restrict pd = ((uint8_t *)y + 0*bs);
+    uint8_t * restrict pb = ((uint8_t *)y + 0*bs + sizeof(float));
+
+    uint8_t pp[QK/2];
+
+    for (int i = 0; i < nb; i++) {
+        float amax = 0.0f; // absolute max
+
+        for (int l = 0; l < QK; l++) {
+            const float v = x[i*QK + l];
+            amax = MAX(amax, fabsf(v));
+        }
+
+        const float d = amax / ((1 << 3) - 1);
+        const float id = d ? 1.0f/d : 0.0f;
+
+        *(float *)pd = d;
+        pd += bs;
+
+        for (int l = 0; l < QK; l += 2) {
+            const float v0 = x[i*QK + l + 0]*id;
+            const float v1 = x[i*QK + l + 1]*id;
+
+            const uint8_t vi0 = ((int8_t) (round(v0))) + 8;
+            const uint8_t vi1 = ((int8_t) (round(v1))) + 8;
+
+            assert(vi0 >= 0 && vi0 < 16);
+            assert(vi1 >= 0 && vi1 < 16);
+
+            pp[l/2] = vi0 | (vi1 << 4);
+        }
+
+        memcpy(pb, pp, sizeof(pp));
+        pb += bs;
+    }
+}
 
 // method 5
 // blocks of QK elements
@@ -10629,6 +10676,69 @@ enum ggml_opt_result ggml_opt(
 
     return result;
 }
+
+////////////////////////////////////////////////////////////////////////////////
+
+size_t ggml_quantize_q4_0(const float * src, void * dst, int n, int k, int qk, int64_t * hist) {
+    const int nb = k / qk;
+    const size_t bs = (sizeof(float) + sizeof(uint8_t)*qk/2);
+    const size_t row_size = nb*bs;
+
+    assert(k % qk == 0);
+
+    char * pdst = (char *) dst;
+
+    for (int j = 0; j < n; j += k) {
+        uint8_t * pd = (uint8_t *) (pdst + (j/k)*row_size + 0*bs);
+        uint8_t * pb = (uint8_t *) (pdst + (j/k)*row_size + 0*bs + sizeof(float));
+
+        quantize_row_q4_0_reference(src + j, pd, k);
+
+        for (int i = 0; i < nb; i++) {
+            for (int l = 0; l < qk; l += 2) {
+                const uint8_t vi0 = pb[l/2] & 0xF;
+                const uint8_t vi1 = pb[l/2] >> 4;
+
+                hist[vi0]++;
+                hist[vi1]++;
+            }
+            pb += bs;
+        }
+    }
+
+    return (n/k)*row_size;
+}
+
+size_t ggml_quantize_q4_1(const float * src, void * dst, int n, int k, int qk, int64_t * hist) {
+    const int nb = k / qk;
+    const size_t bs = (2*sizeof(float) + sizeof(uint8_t)*qk/2);
+    const size_t row_size = nb*bs;
+
+    assert(k % qk == 0);
+
+    char * pdst = (char *) dst;
+
+    for (int j = 0; j < n; j += k) {
+        uint8_t * pd = (uint8_t *) (pdst + (j/k)*row_size + 0*bs);
+        uint8_t * pb = (uint8_t *) (pdst + (j/k)*row_size + 0*bs + 2*sizeof(float));
+
+        quantize_row_q4_1(src + j, pd, k);
+
+        for (int i = 0; i < nb; i++) {
+            for (int l = 0; l < qk; l += 2) {
+                const uint8_t vi0 = pb[l/2] & 0xF;
+                const uint8_t vi1 = pb[l/2] >> 4;
+
+                hist[vi0]++;
+                hist[vi1]++;
+            }
+            pb += bs;
+        }
+    }
+
+    return (n/k)*row_size;
+}
+
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/ggml-raw/ggml/ggml.h
+++ b/ggml-raw/ggml/ggml.h
@@ -742,6 +742,14 @@ enum ggml_opt_result ggml_opt(
         struct ggml_tensor * f);
 
 //
+// quantization
+//
+
+size_t ggml_quantize_q4_0(const float * src, void * dst, int n, int k, int qk, int64_t * hist);
+size_t ggml_quantize_q4_1(const float * src, void * dst, int n, int k, int qk, int64_t * hist);
+
+
+//
 // system info
 //
 

--- a/ggml-raw/src/lib.rs
+++ b/ggml-raw/src/lib.rs
@@ -228,4 +228,24 @@ extern "C" {
     pub fn ggml_build_forward_expand(cgraph: *mut ggml_cgraph, tensor: *mut ggml_tensor);
 
     pub fn ggml_graph_compute(ctx: *mut ggml_context, cgraph: *mut ggml_cgraph);
+
+    pub fn ggml_quantize_q4_0(
+        src: *mut f32,
+        work: *mut c_void,
+        n: i32,
+        k: i32,
+        qk: i32,
+        hist: *mut i64,
+    ) -> usize;
+
+    pub fn ggml_quantize_q4_1(
+        src: *mut f32,
+        work: *mut c_void,
+        n: i32,
+        k: i32,
+        qk: i32,
+        hist: *mut i64,
+    ) -> usize;
+
+    pub fn ggml_fp16_to_fp32(x: u16) -> f32;
 }

--- a/llama-rs/Cargo.toml
+++ b/llama-rs/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.65"
 
 [dependencies]
 bytemuck = "1.13.1"
+half = "2.2.1"
 ggml-raw = { path = "../ggml-raw" }
 partial_sort = "0.2.0"
 thiserror = "1.0"

--- a/llama-rs/src/ggml.rs
+++ b/llama-rs/src/ggml.rs
@@ -6,8 +6,8 @@ use std::{
 
 pub use ggml_raw::ggml_type as Type;
 
-pub const FILE_MAGIC: i32 = 0x67676d66;
-pub const FILE_MAGIC_UNVERSIONED: i32 = 0x67676d6c;
+pub const FILE_MAGIC: u32 = 0x67676d66;
+pub const FILE_MAGIC_UNVERSIONED: u32 = 0x67676d6c;
 
 pub const FORMAT_VERSION: u32 = 1;
 
@@ -290,4 +290,48 @@ pub fn type_sizef(x: ggml_raw::ggml_type) -> f64 {
 
 pub fn blck_size(t: Type) -> i32 {
     unsafe { ggml_raw::ggml_blck_size(t) }
+}
+
+pub fn quantize_q4_0(
+    src: &mut Vec<f32>,
+    work: &mut Vec<f32>,
+    n: i32,
+    k: i32,
+    qk: i32,
+    hist: &mut Vec<i64>,
+) -> usize {
+    unsafe {
+        ggml_raw::ggml_quantize_q4_0(
+            src.as_mut_ptr(),
+            work.as_mut_ptr() as *mut c_void,
+            n,
+            k,
+            qk,
+            hist.as_mut_ptr(),
+        )
+    }
+}
+
+pub fn quantize_q4_1(
+    src: &mut Vec<f32>,
+    work: &mut Vec<f32>,
+    n: i32,
+    k: i32,
+    qk: i32,
+    hist: &mut Vec<i64>,
+) -> usize {
+    unsafe {
+        ggml_raw::ggml_quantize_q4_1(
+            src.as_mut_ptr(),
+            work.as_mut_ptr() as *mut c_void,
+            n,
+            k,
+            qk,
+            hist.as_mut_ptr(),
+        )
+    }
+}
+
+pub fn ggml_fp16_to_fp32(x: u16) -> f32 {
+    unsafe { ggml_raw::ggml_fp16_to_fp32(x) }
 }

--- a/llama-rs/src/quantize.rs
+++ b/llama-rs/src/quantize.rs
@@ -1,0 +1,343 @@
+use crate::ggml::{
+    quantize_q4_0, quantize_q4_1, FILE_MAGIC, FILE_MAGIC_UNVERSIONED, FORMAT_VERSION, TYPE_Q4_0,
+    TYPE_Q4_1,
+};
+use crate::{Hyperparameters, LoadError, Vocabulary};
+use half::f16;
+use std::fs::File;
+use std::io::{BufReader, BufWriter, Read, Write};
+use std::path::Path;
+use thiserror::Error;
+
+const FTYPE_STR: [&str; 4] = ["f32", "f16", "q4_0", "q4_1"];
+
+pub fn llama_model_quantize(
+    file_name_in: impl AsRef<Path>,
+    file_name_out: impl AsRef<Path>,
+    itype: u8,
+    qk: u8,
+) -> Result<bool, LoadError> {
+    let mut otype = TYPE_Q4_1;
+
+    match itype {
+        2 => otype = TYPE_Q4_0,
+        3 => otype = TYPE_Q4_1,
+        _ => {
+            return Err(LoadError::InvalidItype(itype));
+        }
+    };
+
+    let file_in = file_name_in.as_ref();
+    let mut finp = BufReader::new(File::open(file_in).map_err(|e| LoadError::OpenFileFailed {
+        source: e,
+        path: file_in.to_owned(),
+    })?);
+
+    let file_out = file_name_out.as_ref();
+    let mut fout =
+        BufWriter::new(
+            File::create(file_out).map_err(|e| LoadError::CreateFileFailed {
+                source: e,
+                path: file_out.to_owned(),
+            })?,
+        );
+
+    // Verify magic
+    {
+        let mut magic_buffer: [u8; 4] = [0; 4];
+        finp.read_exact(&mut magic_buffer).unwrap();
+
+        let magic = u32::from_le_bytes(magic_buffer);
+        if magic == FILE_MAGIC_UNVERSIONED {
+            return Err(LoadError::UnversionedMagic);
+        }
+        if magic != FILE_MAGIC {
+            return Err(LoadError::InvalidMagic {
+                path: file_in.to_owned(),
+            });
+        }
+
+        fout.write(&magic_buffer).unwrap();
+
+        let mut version_buffer: [u8; 4] = [0; 4];
+        finp.read_exact(&mut version_buffer).unwrap();
+
+        let format_version = u32::from_le_bytes(version_buffer);
+
+        if format_version != FORMAT_VERSION {
+            return Err(LoadError::InvalidFormatVersion {
+                value: format_version,
+            });
+        }
+
+        fout.write(&version_buffer).unwrap();
+    }
+
+    let mut hparams = Hyperparameters::default();
+
+    // Load parameters
+    {
+        let mut buffer: [u8; 4] = [0; 4];
+        finp.read_exact(&mut buffer).unwrap();
+        hparams.n_vocab = i32::from_le_bytes(buffer);
+        println!("n_vocab: {}", hparams.n_vocab);
+        fout.write(&buffer).unwrap();
+
+        finp.read_exact(&mut buffer).unwrap();
+        hparams.n_embd = i32::from_le_bytes(buffer);
+        println!("n_embd: {}", hparams.n_embd);
+        fout.write(&buffer).unwrap();
+
+        finp.read_exact(&mut buffer).unwrap();
+        hparams.n_mult = i32::from_le_bytes(buffer);
+        println!("n_mult: {}", hparams.n_mult);
+        fout.write(&buffer).unwrap();
+
+        finp.read_exact(&mut buffer).unwrap();
+        hparams.n_head = i32::from_le_bytes(buffer);
+        println!("n_head: {}", hparams.n_head);
+        fout.write(&buffer).unwrap();
+
+        finp.read_exact(&mut buffer).unwrap();
+        hparams.n_layer = i32::from_le_bytes(buffer);
+        println!("n_layer: {}", hparams.n_layer);
+        fout.write(&buffer).unwrap();
+
+        finp.read_exact(&mut buffer).unwrap();
+        hparams.n_rot = i32::from_le_bytes(buffer);
+        println!("n_rot: {}", hparams.n_rot);
+        fout.write(&buffer).unwrap();
+
+        finp.read_exact(&mut buffer).unwrap();
+        hparams.f16_ = i32::from_le_bytes(buffer);
+        println!("f16_: {}", hparams.f16_);
+        fout.write(&(itype as i32).to_le_bytes()).unwrap();
+    }
+
+    // load vocab
+    let mut vocab = Vocabulary {
+        id_to_token: vec![],
+        id_to_token_score: vec![],
+        token_to_id: Default::default(),
+        max_token_length: 0,
+    };
+
+    {
+        let n_vocab = hparams.n_vocab;
+
+        for i in 0..n_vocab {
+            let mut len_buffer = [0u8; 4];
+            finp.read_exact(&mut len_buffer).unwrap();
+            fout.write(&len_buffer).unwrap();
+            let len = u32::from_le_bytes(len_buffer) as usize;
+
+            let mut word_buffer = vec![0u8; len];
+            finp.read_exact(word_buffer.as_mut_slice()).unwrap();
+            fout.write(&word_buffer).unwrap();
+
+            let word = String::from_utf8_lossy(&word_buffer).to_string();
+
+            let mut score_buffer = [0u8; 4];
+            finp.read_exact(&mut score_buffer).unwrap();
+            fout.write(&score_buffer).unwrap();
+            let score = f32::from_le_bytes(score_buffer);
+
+            vocab.token_to_id.insert(word.clone(), i);
+
+            vocab.id_to_token.push(word);
+            vocab.id_to_token_score.push(score);
+        }
+    }
+
+    // Load weights
+    {
+        let mut total_size_org: usize = 0;
+        let mut total_size_new: usize = 0;
+
+        let mut work: Vec<f32> = vec![];
+
+        let mut data_u8: Vec<u8> = vec![];
+        let mut data_f16: Vec<u16> = vec![];
+        let mut data_f32: Vec<f32> = vec![];
+
+        let mut hist_all: Vec<i64> = vec![0; 16];
+
+        loop {
+            let mut buffer = [0u8; 4];
+            if finp.read_exact(&mut buffer).is_err() {
+                break;
+            };
+            let n_dims = i32::from_le_bytes(buffer);
+
+            if finp.read_exact(&mut buffer).is_err() {
+                break;
+            };
+            let length = i32::from_le_bytes(buffer) as usize;
+
+            if finp.read_exact(&mut buffer).is_err() {
+                break;
+            };
+            let mut ftype = i32::from_le_bytes(buffer) as usize;
+
+            println!("n_dims: {}, length: {}, ftype: {} ", n_dims, length, ftype);
+
+            let mut nelements = 1i32;
+            let mut ne = [1i32, 1i32];
+            for i in 0..n_dims {
+                finp.read_exact(&mut buffer).unwrap();
+                ne[i as usize] = i32::from_le_bytes(buffer);
+                nelements *= ne[i as usize];
+            }
+
+            let mut name_buffer = vec![0u8; length];
+            finp.read_exact(&mut name_buffer).unwrap();
+            let name = String::from_utf8(name_buffer).unwrap();
+            println!("Nelements: {}", nelements);
+            print!(
+                "{:>48} - [{:>5}, {:>5}], type = {:>6}",
+                format!("'{}'", name),
+                ne[0],
+                ne[1],
+                FTYPE_STR[ftype]
+            );
+
+            // Quantize only 2D tensors
+            let mut quantize = name.find("weight").is_some() && n_dims == 2;
+
+            if quantize {
+                if ftype != 0 && ftype != 1 {
+                    return Err(LoadError::InvalidFtype {
+                        ftype: ftype as i32,
+                        path: file_in.to_owned(),
+                    });
+                }
+
+                data_f32.resize(nelements as usize, 0.0);
+                if ftype == 1 {
+                    data_f16.resize(nelements as usize, 0);
+
+                    let mut buffer = vec![0u8; (nelements * 2) as usize];
+                    finp.read_exact(&mut buffer).unwrap();
+                    // Compute buffer
+                    for (index, chunk) in buffer.chunks(2).enumerate() {
+                        let i = u16::from_le_bytes([chunk[0], chunk[1]]);
+                        data_f16[index] = i;
+
+                        //data_f32[index] = ggml_fp16_to_fp32(i);
+                        data_f32[index] = f16::from_bits(i).to_f32();
+                    }
+                } else {
+                    let mut buffer = vec![0u8; (nelements * 4) as usize];
+                    finp.read_exact(&mut buffer).unwrap();
+
+                    for (index, chunk) in buffer.chunks(4).enumerate() {
+                        data_f32[index] =
+                            f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+                    }
+                }
+
+                ftype = itype as usize;
+            } else {
+                // Determines the total bytes were dealing with
+                let bpe = (nelements * if ftype == 0 { 4 } else { 2 }) as usize;
+
+                data_u8.resize(bpe, 0);
+                finp.read_exact(&mut data_u8).unwrap();
+            }
+
+            // Write data
+            fout.write(&n_dims.to_le_bytes()).unwrap();
+            fout.write(&(length as i32).to_le_bytes()).unwrap();
+            println!(" new ftype: {}", ftype);
+            println!("{:?}", name.as_bytes());
+            fout.write(&(ftype as i32).to_le_bytes()).unwrap();
+
+            for i in 0..n_dims {
+                fout.write(&ne[i as usize].to_le_bytes()).unwrap();
+            }
+            fout.write(name.as_bytes()).unwrap();
+
+            if quantize {
+                print!("quantizing .. ");
+                work.resize(nelements as usize, 0.0);
+
+                let curr_size;
+                let mut hist_cur = vec![0; 16];
+
+                match otype {
+                    TYPE_Q4_0 => {
+                        curr_size = quantize_q4_0(
+                            &mut data_f32,
+                            &mut work,
+                            nelements,
+                            ne[0],
+                            qk as i32,
+                            &mut hist_cur,
+                        )
+                    }
+                    TYPE_Q4_1 => {
+                        curr_size = quantize_q4_1(
+                            &mut data_f32,
+                            &mut work,
+                            nelements,
+                            ne[0],
+                            qk as i32,
+                            &mut hist_cur,
+                        )
+                    }
+                    _ => {
+                        println!("Unsupported type");
+                        return Ok(false);
+                    }
+                }
+
+                // We divide curr size by 4
+                for i in 0..curr_size / 4 {
+                    fout.write(&work[i].to_le_bytes()).unwrap();
+                }
+
+                total_size_new += curr_size;
+
+                print!(
+                    "size = {:>8.2} MB -> {:>8.2} MB | hist: ",
+                    nelements as f32 * 4.0 / 1024.0 / 1024.0,
+                    curr_size as f32 / 1024.0 / 1024.0
+                );
+
+                for (i, val) in hist_cur.iter().enumerate() {
+                    hist_all[i] += val;
+                    print!("{:>5.3} ", *val as f32 / nelements as f32);
+                }
+                println!();
+            } else {
+                fout.write(&data_u8).unwrap();
+                println!("size = {:>8.3} MB", data_u8.len() as f64 / 1024.0 / 1024.0);
+                total_size_new += data_u8.len();
+            }
+
+            total_size_org += (nelements * 4) as usize;
+        }
+
+        println!(
+            "model size: {:>8.2}",
+            total_size_org as f32 / 1024.0 / 1024.0
+        );
+
+        println!(
+            "quant size: {:>8.2}",
+            total_size_new as f32 / 1024.0 / 1024.0
+        );
+
+        {
+            let sum_all: i64 = hist_all.iter().sum();
+
+            print!("hist: ");
+            for hist in hist_all {
+                print!("{:>5.3} ", hist as f32 / sum_all as f32);
+            }
+            println!();
+        }
+    }
+
+    return Ok(true);
+}


### PR DESCRIPTION
I went ahead and ported the main `quantize.cpp` file. My changes involve porting the file while keeping the internal C++ function calls intact. I have plans to port those function calls to remove ggml dependencies in a future PR though.

During the porting process, I faced some challenges as I was not familiar with how to use `Context`. As a result, I added the `half` library to handle the f16->f32 conversion. I could remove the dependency if needed but ill need some help with working with `Context`. Something to note on this is that if there are plant to move away from ggml then the `half` library will be necessary. 

Additionally, I included some print statements inside the function to mimic the original behavior of quantize.cpp. I can remove those if needed.

Currently, there is no way to access the function since I did not implement a CLI function for it. 

I am open to feedback and suggestions on how to improve this pull request.

Resolves #40 