### PR TITLE
Fix for the --batch-size parameter

### DIFF
--- a/llama-cli/src/main.rs
+++ b/llama-cli/src/main.rs
@@ -16,13 +16,13 @@ fn repl_mode(
     vocab: &llama_rs::Vocabulary,
     params: &InferenceParameters,
     session_params: &InferenceSessionParameters,
+    mut session: InferenceSession,
 ) {
     let mut rl = rustyline::DefaultEditor::new().unwrap();
     loop {
         let readline = rl.readline(">> ");
         match readline {
             Ok(line) => {
-                let mut session = model.start_session(*session_params);
                 let prompt = prompt.replace("$PROMPT", &line);
                 let mut rng = thread_rng();
 
@@ -250,6 +250,7 @@ fn main() {
             &vocab,
             &inference_params,
             &inference_session_params,
+            session,
         );
     } else {
         let inference_params = if session_loaded {

--- a/llama-rs/src/lib.rs
+++ b/llama-rs/src/lib.rs
@@ -1461,7 +1461,7 @@ impl InferenceSession {
             return Err(InferenceError::ContextFull);
         }
 
-        for batch in prompt_tokens.chunks(8) {
+        for batch in prompt_tokens.chunks(params.n_batch) {
             model.evaluate(self, params, batch, &mut EvaluateOutputRequest::default());
             for &tk in batch {
                 // NOTE: No string ever tokenizes to the end of sentence. So we


### PR DESCRIPTION
The default value was being used regardless of the value provided by the user.