### PR TITLE
Fix num_threads flag being ignored

### DIFF
--- a/llama-cli/src/cli_args.rs
+++ b/llama-cli/src/cli_args.rs
@@ -142,7 +142,8 @@ impl Args {
     }
 
     pub(crate) fn num_threads(&self) -> usize {
-        self.num_threads.unwrap_or_else(|| self.autodetect_num_threads())
+        self.num_threads
+            .unwrap_or_else(|| self.autodetect_num_threads())
     }
 }
 

--- a/llama-cli/src/cli_args.rs
+++ b/llama-cli/src/cli_args.rs
@@ -126,7 +126,7 @@ pub struct Args {
 }
 impl Args {
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    pub(crate) fn num_threads(&self) -> usize {
+    pub(crate) fn autodetect_num_threads(&self) -> usize {
         std::process::Command::new("sysctl")
             .arg("-n")
             .arg("hw.perflevel0.physicalcpu")
@@ -137,8 +137,12 @@ impl Args {
     }
 
     #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
-    pub(crate) fn num_threads(&self) -> usize {
+    pub(crate) fn autodetect_num_threads(&self) -> usize {
         num_cpus::get_physical()
+    }
+
+    pub(crate) fn num_threads(&self) -> usize {
+        self.num_threads.unwrap_or_else(|| self.autodetect_num_threads())
     }
 }
 


### PR DESCRIPTION
Some previous changes broke the num_threads flag in `llama_cli`. This PR restores the original behavior of obeying the value for the -t flag, and only using the autodetected value when none is set.