### PR TITLE
Bump ggml version to fix compilation bug on aarch64

### DIFF
--- a/ggml-sys/ggml/ggml.c
+++ b/ggml-sys/ggml/ggml.c
@@ -1038,8 +1038,8 @@ static void dequantize_row_q4_1(const void * restrict vx, float * restrict y, in
             const uint8x16_t vq = vcombine_u8(vx_0, vx_1);
 
             // convert to 2x uint16x8_t
-            const uint16x8_t vi_0 = vmovl_s8(vget_low_u8 (vq));
-            const uint16x8_t vi_1 = vmovl_s8(vget_high_u8(vq));
+            const uint16x8_t vi_0 = vmovl_u8(vget_low_u8 (vq));
+            const uint16x8_t vi_1 = vmovl_u8(vget_high_u8(vq));
 
             // convert to 4x float32x4_t
             const float32x4_t vf_0 = vcvtq_f32_u32(vmovl_u16(vget_low_u16 (vi_0)));


### PR DESCRIPTION
On aarch64 (tested on m1 MacBook), compilation fails with the below message. It looks like this problem was fixed in ggml recently in https://github.com/ggerganov/ggml/commit/652c0c01521e8eb8a977463dce865839259cd02f. This PR syncs the local ggml.c with upstream.

```
error: failed to run custom build command for `ggml-sys v0.1.0 (/llama-rs/ggml-sys)`

Caused by:
  process didn't exit successfully: `/llama-rs/target/debug/build/ggml-sys-796dc0784457db96/build-script-build` (exit status: 1)
  --- stdout
  cargo:rerun-if-changed=ggml
  OPT_LEVEL = Some("0")
  TARGET = Some("aarch64-unknown-linux-gnu")
  HOST = Some("aarch64-unknown-linux-gnu")
  cargo:rerun-if-env-changed=CC_aarch64-unknown-linux-gnu
  CC_aarch64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CC_aarch64_unknown_linux_gnu
  CC_aarch64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_CC
  HOST_CC = None
  cargo:rerun-if-env-changed=CC
  CC = None
  cargo:rerun-if-env-changed=CFLAGS_aarch64-unknown-linux-gnu
  CFLAGS_aarch64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CFLAGS_aarch64_unknown_linux_gnu
  CFLAGS_aarch64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_CFLAGS
  HOST_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some("true")
  CARGO_CFG_TARGET_FEATURE = Some("neon")
  running: "cc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-I" "include" "-mcpu=native" "-pthread" "-o" "/llama-rs/target/debug/build/ggml-sys-809c6ec9c698a44e/out/ggml/ggml.o" "-c" "ggml/ggml.c"
  cargo:warning=ggml/ggml.c: In function 'dequantize_row_q4_1':
  cargo:warning=ggml/ggml.c:1041:13: note: use '-flax-vector-conversions' to permit conversions between vectors with differing element types or numbers of subparts
  cargo:warning= 1041 |             const uint16x8_t vi_0 = vmovl_s8(vget_low_u8 (vq));
  cargo:warning=      |             ^~~~~
  cargo:warning=ggml/ggml.c:1041:46: error: incompatible type for argument 1 of 'vmovl_s8'
  cargo:warning= 1041 |             const uint16x8_t vi_0 = vmovl_s8(vget_low_u8 (vq));
  cargo:warning=      |                                              ^~~~~~~~~~~~~~~~
  cargo:warning=      |                                              |
  cargo:warning=      |                                              uint8x8_t
  cargo:warning=In file included from ggml/ggml.c:164:
  cargo:warning=/usr/lib/gcc/aarch64-linux-gnu/10/include/arm_neon.h:8830:20: note: expected 'int8x8_t' but argument is of type 'uint8x8_t'
  cargo:warning= 8830 | vmovl_s8 (int8x8_t __a)
  cargo:warning=      |           ~~~~~~~~~^~~
  cargo:warning=ggml/ggml.c:1042:46: error: incompatible type for argument 1 of 'vmovl_s8'
  cargo:warning= 1042 |             const uint16x8_t vi_1 = vmovl_s8(vget_high_u8(vq));
  cargo:warning=      |                                              ^~~~~~~~~~~~~~~~
  cargo:warning=      |                                              |
  cargo:warning=      |                                              uint8x8_t
  cargo:warning=In file included from ggml/ggml.c:164:
  cargo:warning=/usr/lib/gcc/aarch64-linux-gnu/10/include/arm_neon.h:8830:20: note: expected 'int8x8_t' but argument is of type 'uint8x8_t'
  cargo:warning= 8830 | vmovl_s8 (int8x8_t __a)
  cargo:warning=      |           ~~~~~~~~~^~~
  exit status: 1

  --- stderr


  error occurred: Command "cc" "-O0" "-ffunction-sections" "-fdata-sections" "-fPIC" "-gdwarf-4" "-fno-omit-frame-pointer" "-I" "include" "-mcpu=native" "-pthread" "-o" "/llama-rs/target/debug/build/ggml-sys-809c6ec9c698a44e/out/ggml/ggml.o" "-c" "ggml/ggml.c" with args "cc" did not execute successfully (status code exit status: 1).


warning: build failed, waiting for other jobs to finish...
```
