### PR TITLE
fix: cross compile from non-apple silicon host to apple silicon

### DIFF
--- a/ggml-sys/build.rs
+++ b/ggml-sys/build.rs
@@ -58,6 +58,14 @@ fn main() {
             if compiler.is_like_clang() || compiler.is_like_gnu() {
                 if std::env::var("HOST") == std::env::var("TARGET") {
                     build.flag("-mcpu=native");
+                } else {
+                    match target_os.as_str() {
+                        "macos" => {
+                            build.flag("-mcpu=apple-m1");
+                            build.flag("-mfpu=neon");
+                        }
+                        _ => {}
+                    }
                 }
                 build.flag("-pthread");
             }

--- a/ggml-sys/build.rs
+++ b/ggml-sys/build.rs
@@ -56,7 +56,9 @@ fn main() {
         }
         "aarch64" => {
             if compiler.is_like_clang() || compiler.is_like_gnu() {
-                build.flag("-mcpu=native");
+                if std::env::var("HOST") == std::env::var("TARGET") {
+                    build.flag("-mcpu=native");
+                }
                 build.flag("-pthread");
             }
         }

--- a/ggml-sys/build.rs
+++ b/ggml-sys/build.rs
@@ -59,6 +59,7 @@ fn main() {
                 if std::env::var("HOST") == std::env::var("TARGET") {
                     build.flag("-mcpu=native");
                 } else {
+                    #[allow(clippy::single_match)]
                     match target_os.as_str() {
                         "macos" => {
                             build.flag("-mcpu=apple-m1");


### PR DESCRIPTION
Hi, this should solve the apple m1 targeting cross compile problem. We should check if host platform is same as target platform, if same, we enable mcpu=native, otherwise we manually setup the flags