### PR TITLE
Change Rust-side GGML view ops to take element rather than byte arguments.

### DIFF
--- a/ggml/src/lib.rs
+++ b/ggml/src/lib.rs
@@ -235,6 +235,7 @@ impl Context {
 
     /// Creates a 1D view over `a`.
     pub fn op_view_1d(&self, a: &Tensor, ne0: usize, offset: usize) -> Tensor {
+        let offset = offset * a.element_size();
         let tensor = unsafe {
             ggml_sys::ggml_view_1d(self.ptr.as_ptr(), a.ptr.as_ptr(), usize_to_i64(ne0), offset)
         };
@@ -250,6 +251,10 @@ impl Context {
         nb1: usize,
         offset: usize,
     ) -> Tensor {
+        let elsize = a.element_size();
+        let offset = offset * elsize;
+        let nb1 = nb1 * elsize;
+
         let tensor = unsafe {
             ggml_sys::ggml_view_2d(
                 self.ptr.as_ptr(),
@@ -275,6 +280,11 @@ impl Context {
         nb2: usize,
         offset: usize,
     ) -> Tensor {
+        let elsize = a.element_size();
+        let offset = offset * elsize;
+        let nb1 = nb1 * elsize;
+        let nb2 = nb2 * elsize;
+
         let tensor = unsafe {
             ggml_sys::ggml_view_3d(
                 self.ptr.as_ptr(),

--- a/llama-rs/src/lib.rs
+++ b/llama-rs/src/lib.rs
@@ -1130,9 +1130,6 @@ impl Model {
         let n_past = session.n_past;
         let n_threads = params.n_threads;
 
-        let memk_elsize = session.memory_k.element_size();
-        let memv_elsize = session.memory_v.element_size();
-
         let Hyperparameters {
             n_vocab,
             n_ctx,
@@ -1213,15 +1210,15 @@ impl Model {
                     let k = ctx0.op_view_1d(
                         &session.memory_k,
                         n * n_embd,
-                        (memk_elsize * n_embd) * (il * n_ctx + n_past),
+                        n_embd * (il * n_ctx + n_past),
                     );
 
                     let v = ctx0.op_view_2d(
                         &session.memory_v,
                         n,
                         n_embd,
-                        n_ctx * memv_elsize,
-                        (il * n_ctx) * memv_elsize * n_embd + n_past * memv_elsize,
+                        n_ctx,
+                        (il * n_ctx) * n_embd + n_past,
                     );
 
                     // important: storing RoPE-ed version of K in the KV cache!
@@ -1236,7 +1233,7 @@ impl Model {
                         &ctx0.op_view_1d(
                             &session.memory_k,
                             (n_past + n) * n_embd,
-                            il * n_ctx * memk_elsize * n_embd,
+                            il * n_ctx * n_embd,
                         ),
                         n_embd / n_head,
                         n_head,
@@ -1269,9 +1266,9 @@ impl Model {
                     n_past + n,
                     n_embd / n_head,
                     n_head,
-                    n_ctx * memv_elsize,
-                    n_ctx * memv_elsize * n_embd / n_head,
-                    il * n_ctx * memv_elsize * n_embd,
+                    n_ctx,
+                    n_ctx * n_embd / n_head,
+                    il * n_ctx * n_embd,
                 );
 
                 let k_q_v = ctx0.op_mul_mat(&v, &k_q_soft_max);


### PR DESCRIPTION
I think this is kind of a no-brainer change because it I can't think of a reason one would want to view a tensor except at the granularity of the elements. Source: Trust me bro.

I'd like to propose this as something that comes in before the 0.1 release because it would be a breaking API change.