### PR TITLE
Add color_eyre for cli error handling

### DIFF
--- a/llama-cli/Cargo.toml
+++ b/llama-cli/Cargo.toml
@@ -19,3 +19,4 @@ once_cell = "1.17.1"
 rustyline = "11.0.0"
 spinners = "4.1.0"
 zstd = { version = "0.12", default-features = false }
+color-eyre = { version = "0.6.2", default-features = false }

--- a/llama-cli/src/cli_args.rs
+++ b/llama-cli/src/cli_args.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
+use color_eyre::eyre::{Result, WrapErr};
 use llama_rs::{
     InferenceParameters, InferenceSessionParameters, ModelKVMemoryType, TokenBias, EOT_TOKEN_ID,
 };
@@ -260,7 +261,7 @@ pub struct ModelLoad {
     pub num_ctx_tokens: usize,
 }
 impl ModelLoad {
-    pub fn load(&self) -> llama_rs::Model {
+    pub fn load(&self) -> Result<llama_rs::Model> {
         let model = llama_rs::Model::load(&self.model_path, self.num_ctx_tokens, |progress| {
             use llama_rs::LoadProgress;
             match progress {
@@ -308,11 +309,11 @@ impl ModelLoad {
                 }
             }
         })
-        .expect("Could not load model");
+        .wrap_err("Failed to load model")?;
 
         log::info!("Model fully loaded!");
 
-        model
+        Ok(model)
     }
 }
 

--- a/llama-cli/src/main.rs
+++ b/llama-cli/src/main.rs
@@ -2,32 +2,36 @@ use std::{convert::Infallible, io::Write};
 
 use clap::Parser;
 use cli_args::Args;
+use color_eyre::eyre::Result;
 use llama_rs::{convert::convert_pth_to_ggml, InferenceError};
 use rustyline::error::ReadlineError;
 
 mod cli_args;
 mod snapshot;
 
-fn main() {
+fn main() -> Result<()> {
     env_logger::builder()
         .filter_level(log::LevelFilter::Info)
         .parse_default_env()
         .init();
+    color_eyre::install()?;
 
     let cli_args = Args::parse();
     match cli_args {
-        Args::Infer(args) => infer(&args),
-        Args::DumpTokens(args) => dump_tokens(&args),
-        Args::Repl(args) => interactive(&args, false),
-        Args::ChatExperimental(args) => interactive(&args, true),
+        Args::Infer(args) => infer(&args)?,
+        Args::DumpTokens(args) => dump_tokens(&args)?,
+        Args::Repl(args) => interactive(&args, false)?,
+        Args::ChatExperimental(args) => interactive(&args, true)?,
         Args::Convert(args) => convert_pth_to_ggml(&args.directory, args.element_type.into()),
     }
+
+    Ok(())
 }
 
-fn infer(args: &cli_args::Infer) {
+fn infer(args: &cli_args::Infer) -> Result<()> {
     let prompt = load_prompt_file_with_prompt(&args.prompt_file, args.prompt.as_deref());
     let inference_session_params = args.generate.inference_session_parameters();
-    let model = args.model_load.load();
+    let model = args.model_load.load()?;
     let (mut session, session_loaded) = snapshot::read_or_create_session(
         &model,
         args.persist_session.as_deref(),
@@ -68,11 +72,13 @@ fn infer(args: &cli_args::Infer) {
         // Write the memory to the cache file
         snapshot::write_session(session, session_path);
     }
+
+    Ok(())
 }
 
-fn dump_tokens(args: &cli_args::DumpTokens) {
+fn dump_tokens(args: &cli_args::DumpTokens) -> Result<()> {
     let prompt = load_prompt_file_with_prompt(&args.prompt_file, args.prompt.as_deref());
-    let model = args.model_load.load();
+    let model = args.model_load.load()?;
     let toks = match model.vocabulary().tokenize(&prompt, false) {
         Ok(toks) => toks,
         Err(e) => {
@@ -95,6 +101,8 @@ fn dump_tokens(args: &cli_args::DumpTokens) {
             .collect::<Vec<_>>()
             .join(", ")
     );
+
+    Ok(())
 }
 
 fn interactive(
@@ -102,10 +110,10 @@ fn interactive(
     // If set to false, the session will be cloned after each inference
     // to ensure that previous state is not carried over.
     chat_mode: bool,
-) {
+) -> Result<()> {
     let prompt_file = args.prompt_file.contents();
     let inference_session_params = args.generate.inference_session_parameters();
-    let model = args.model_load.load();
+    let model = args.model_load.load()?;
     let (mut session, session_loaded) = snapshot::read_or_create_session(
         &model,
         None,
@@ -115,7 +123,7 @@ fn interactive(
     let inference_params = args.generate.inference_parameters(session_loaded);
 
     let mut rng = args.generate.rng();
-    let mut rl = rustyline::DefaultEditor::new().unwrap();
+    let mut rl = rustyline::DefaultEditor::new()?;
     loop {
         let readline = rl.readline(">> ");
         match readline {
@@ -172,6 +180,8 @@ fn interactive(
             }
         }
     }
+
+    Ok(())
 }
 
 fn load_prompt_file_with_prompt(


### PR DESCRIPTION
We have nice error messages via `thiserror` - let's use them! 
This PR uses `color_eyre` to get fancier error messages, including tracking context around errors to make debugging easier.

There's probably more error handling we could convert to this approach, but this is decent starting point.