### PR TITLE
fix #149 - load tensors by type, ignoring filetype

### DIFF
--- a/ggml-loader/Cargo.toml
+++ b/ggml-loader/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 ggml = { path = "../ggml" }
-thiserror = "*"
+thiserror = "1.0"

--- a/ggml-loader/src/util.rs
+++ b/ggml-loader/src/util.rs
@@ -1,7 +1,7 @@
 pub use std::io::{BufRead, Seek, SeekFrom};
 use std::ops::ControlFlow;
 
-use crate::{ElementType, LoadError};
+use crate::LoadError;
 
 pub fn read_bytes<const N: usize>(reader: &mut impl BufRead) -> Result<[u8; N], std::io::Error> {
     let mut bytes = [0u8; N];
@@ -33,33 +33,6 @@ pub fn read_bytes_with_len(
 // NOTE: Implementation from #![feature(buf_read_has_data_left)]
 pub fn has_data_left(reader: &mut impl BufRead) -> Result<bool, std::io::Error> {
     reader.fill_buf().map(|b| !b.is_empty())
-}
-
-pub fn decode_element_type(ftype: i32) -> Option<ElementType> {
-    match ftype {
-        0 => Some(ggml::Type::F32),
-        1 => Some(ggml::Type::F16),
-        2 => Some(ggml::Type::Q4_0),
-        3 => Some(ggml::Type::Q4_1),
-        _ => None,
-    }
-}
-
-pub fn encode_element_type(element_type: ElementType) -> Option<i32> {
-    match element_type {
-        ggml::Type::F32 => Some(0),
-        ggml::Type::F16 => Some(1),
-        ggml::Type::Q4_0 => Some(2),
-        ggml::Type::Q4_1 => Some(3),
-        _ => None,
-    }
-}
-
-pub fn decode_element_type_res<T>(ftype: i32) -> Result<ElementType, LoadError<T>> {
-    match decode_element_type(ftype) {
-        Some(x) => Ok(x),
-        None => Err(LoadError::UnsupportedElementType(ftype)),
-    }
 }
 
 pub fn controlflow_to_result<A, B>(x: ControlFlow<A, B>) -> Result<B, LoadError<A>> {

--- a/llama-cli/src/cli_args.rs
+++ b/llama-cli/src/cli_args.rs
@@ -373,12 +373,12 @@ pub struct Convert {
     pub directory: PathBuf,
 
     /// File type to convert to
-    #[arg(long, short = 't', value_enum, default_value_t = ElementType::Q4_0)]
-    pub element_type: ElementType,
+    #[arg(long, short = 't', value_enum, default_value_t = FileType::Q4_0)]
+    pub file_type: FileType,
 }
 
 #[derive(Parser, Debug, ValueEnum, Clone, Copy)]
-pub enum ElementType {
+pub enum FileType {
     /// Quantized 4-bit (type 0).
     Q4_0,
     /// Quantized 4-bit (type 1); used by GPTQ.
@@ -388,13 +388,13 @@ pub enum ElementType {
     /// Float 32-bit.
     F32,
 }
-impl From<ElementType> for llama_rs::ElementType {
-    fn from(t: ElementType) -> Self {
+impl From<FileType> for llama_rs::FileType {
+    fn from(t: FileType) -> Self {
         match t {
-            ElementType::Q4_0 => llama_rs::ElementType::Q4_0,
-            ElementType::Q4_1 => llama_rs::ElementType::Q4_1,
-            ElementType::F16 => llama_rs::ElementType::F16,
-            ElementType::F32 => llama_rs::ElementType::F32,
+            FileType::Q4_0 => llama_rs::FileType::MostlyQ4_0,
+            FileType::Q4_1 => llama_rs::FileType::MostlyQ4_1,
+            FileType::F16 => llama_rs::FileType::MostlyF16,
+            FileType::F32 => llama_rs::FileType::F32,
         }
     }
 }

--- a/llama-cli/src/main.rs
+++ b/llama-cli/src/main.rs
@@ -22,7 +22,7 @@ fn main() -> Result<()> {
         Args::DumpTokens(args) => dump_tokens(&args)?,
         Args::Repl(args) => interactive(&args, false)?,
         Args::ChatExperimental(args) => interactive(&args, true)?,
-        Args::Convert(args) => convert_pth_to_ggml(&args.directory, args.element_type.into()),
+        Args::Convert(args) => convert_pth_to_ggml(&args.directory, args.file_type.into()),
     }
 
     Ok(())

--- a/llama-rs/src/inference_session.rs
+++ b/llama-rs/src/inference_session.rs
@@ -68,7 +68,7 @@ impl InferenceSession {
             .map(|(_, tok)| *tok)
             .collect();
 
-        if self.n_past + prompt_tokens.len() >= model.hparams.n_ctx {
+        if self.n_past + prompt_tokens.len() >= model.n_ctx() {
             return Err(InferenceError::ContextFull);
         }
 
@@ -96,7 +96,7 @@ impl InferenceSession {
         params: &InferenceParameters,
         rng: &mut impl rand::Rng,
     ) -> Result<&'v [u8], InferenceError> {
-        if self.n_past + 1 >= model.hparams.n_ctx {
+        if self.n_past + 1 >= model.n_ctx() {
             return Err(InferenceError::ContextFull);
         }
 

--- a/llama-rs/src/lib.rs
+++ b/llama-rs/src/lib.rs
@@ -19,7 +19,7 @@ pub use inference_session::{
     InferenceSession, InferenceSessionParameters, InferenceSnapshot, ModelKVMemoryType,
     SnapshotError,
 };
-pub use loader_common::{LoadError, LoadProgress};
+pub use loader_common::{FileType, LoadError, LoadProgress};
 pub use model::{Hyperparameters, Model};
 pub use util::TokenUtf8Buffer;
 pub use vocabulary::{TokenBias, TokenId, Vocabulary};

--- a/llama-rs/src/loader.rs
+++ b/llama-rs/src/loader.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use crate::{
+    loader_common::FileType,
     util::{self, mulf},
     LoadError, LoadProgress, Model, TokenId, Vocabulary,
 };
@@ -69,9 +70,9 @@ pub(crate) fn load(
         n_head: read_i32(&mut reader)?.try_into()?,
         n_layer: read_i32(&mut reader)?.try_into()?,
         n_rot: read_i32(&mut reader)?.try_into()?,
-        element_type: {
+        file_type: {
             let ftype = read_i32(&mut reader)?;
-            decode_element_type(ftype).ok_or_else(|| LoadError::UnsupportedElementType(ftype))
+            FileType::try_from(ftype).map_err(|_| LoadError::UnsupportedFileType(ftype))
         }?,
     };
 
@@ -108,7 +109,13 @@ pub(crate) fn load(
     // for the big tensors, we have the option to store the data in 16-bit
     // floats or quantized in order to save memory and also to speed up the
     // computation
-    let wtype = hparams.element_type;
+    let wtype = match hparams.file_type {
+        FileType::F32 => ggml::Type::F32,
+        FileType::MostlyF16 => ggml::Type::F16,
+        FileType::MostlyQ4_0 => ggml::Type::Q4_0,
+        FileType::MostlyQ4_1 => ggml::Type::Q4_1,
+        _ => unimplemented!(),
+    };
 
     let n_embd = hparams.n_embd;
     let n_layer = hparams.n_layer;
@@ -159,7 +166,7 @@ pub(crate) fn load(
         (None, None)
     };
 
-    let mut model = Model::new(context, hparams, vocabulary, n_ff, wtype, model_type, mmap);
+    let mut model = Model::new_loader1(context, hparams, vocabulary, n_ff, wtype, mmap);
     match model_type {
         ContainerType::GGMF | ContainerType::GGML => {
             let file_offset = reader.stream_position()?;
@@ -421,7 +428,7 @@ fn load_tensor_header_ggmf<'a>(
 }
 
 fn tensor_type_size(ftype: i32, ne: [i64; 2]) -> Option<usize> {
-    let ftype = decode_element_type(ftype)?;
+    let ftype = ggml::Type::try_from(ftype).ok()?;
     match ftype {
         ElementType::Q4_0 | ElementType::Q4_1 => {
             assert_eq!(ne[0] % 64, 0);

--- a/llama-rs/src/model.rs
+++ b/llama-rs/src/model.rs
@@ -17,7 +17,7 @@ use ggml_loader::TensorInfo;
 /// The weights for the LLaMA model. All the mutable state is split into a
 /// separate struct `InferenceSession`.
 pub struct Model {
-    pub(crate) hparams: Hyperparameters,
+    hyperparameters: Hyperparameters,
 
     vocabulary: Vocabulary,
 
@@ -105,7 +105,7 @@ impl Model {
         }
 
         Model {
-            hparams,
+            hyperparameters: hparams,
             vocabulary,
             tok_embeddings,
             norm,
@@ -249,7 +249,7 @@ impl Model {
         let tensors = tl.loaded_tensors;
 
         Ok(Model {
-            hparams: hyperparameters,
+            hyperparameters,
             vocabulary,
             tok_embeddings,
             norm,
@@ -291,10 +291,10 @@ impl Model {
     pub fn start_session(&self, params: InferenceSessionParameters) -> InferenceSession {
         InferenceSession::new(
             params,
-            self.hparams.n_ctx,
-            self.hparams.n_layer,
-            self.hparams.n_embd,
-            self.hparams.n_vocab,
+            self.hyperparameters.n_ctx,
+            self.hyperparameters.n_layer,
+            self.hyperparameters.n_embd,
+            self.hyperparameters.n_vocab,
         )
     }
 
@@ -327,7 +327,7 @@ impl Model {
             n_layer,
             n_rot,
             file_type: _,
-        } = self.hparams;
+        } = self.hyperparameters;
 
         // For the first run, we need to guess a maximum buffer size so we can measure
         // the actual memory consumption of the temporary ggml context.
@@ -598,6 +598,10 @@ impl Model {
 
     pub(crate) fn tensors_mut(&mut self) -> &mut HashMap<String, ggml::Tensor> {
         &mut self.tensors
+    }
+
+    pub(crate) fn n_ctx(&self) -> usize {
+        self.hyperparameters.n_ctx
     }
 }
 

--- a/llama-rs/src/model.rs
+++ b/llama-rs/src/model.rs
@@ -117,6 +117,7 @@ impl Model {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new_loader2(
         context: ggml::Context,
         hyperparameters: Hyperparameters,


### PR DESCRIPTION
As noticed by @KerfuffleV2, both loaders incorrectly handle newer models that mix tensor types indiscriminately due to a confusion between the `ftype/f16_` and element type.

I was planning on bringing #84 up to date first, but realised that I needed to figure out what was going on with `ftype` before baking that in.

I've addressed the issue by decoupling them properly, and then switching over to loading the tensors from file instead of trying to preallocate them with the wrong type. This mirrors the changes made in https://github.com/ggerganov/llama.cpp/pull/801.

I've tested this with Alpaca 7B GGML and `gpt4-x-alpaca-13b-native-4bit-128g`, the latter with and without `mmap`, and all seems to work.

---

I'm not happy at how I broke the isolation between the loader and the `Model` with `Model::new_loader2`, but I'm going to revisit this once I remove loader1 as part of #150.

`loader1` is still broken (i.e. using the old behaviour), but that's OK because it's going away soon ^_^