### PR TITLE
Add discovered number to magic mismatch error

### DIFF
--- a/llama-rs/src/loader_common.rs
+++ b/llama-rs/src/loader_common.rs
@@ -148,7 +148,7 @@ pub enum LoadError {
     #[error("unsupported f16_: {0}")]
     /// The `f16_` hyperparameter had an invalid value.
     UnsupportedFileType(i32),
-    #[error("invalid magic number for {path:?}")]
+    #[error("invalid magic number {magic:#x} for {path:?}")]
     /// An invalid magic number was encountered during the loading process.
     InvalidMagic {
         /// The path that failed.


### PR DESCRIPTION
This makes it easier to see why a given model isn't loading, since it'll now print the mismatched magic number in the stack of errors.