### PR TITLE
mmap with MAP_POPULATE

### DIFF
--- a/llama-rs/src/loader.rs
+++ b/llama-rs/src/loader.rs
@@ -16,7 +16,6 @@ use ggml_format::{
     util::{has_data_left, read_bytes_with_len, read_f32, read_i32, read_u32},
     ContainerType,
 };
-use memmap2::Mmap;
 
 pub(crate) fn load(
     path: impl AsRef<Path>,
@@ -168,7 +167,7 @@ pub(crate) fn load(
     let context = ggml::Context::init(ctx_size, alloc);
 
     let (mmap, mmap_ptr) = if prefer_mmap && model_type.support_mmap() {
-        let mmap = unsafe { Mmap::map(&file)? };
+        let mmap = util::mmap_populate(&file)?;
         let ptr = mmap.as_ptr();
         (Some(mmap), Some(ptr))
     } else {

--- a/llama-rs/src/loader2.rs
+++ b/llama-rs/src/loader2.rs
@@ -107,7 +107,7 @@ pub(crate) fn load(
 
     let mmap = if use_mmap {
         let file = File::open(&path)?;
-        Some(unsafe { Mmap::map(&file)? })
+        Some(util::mmap_populate(&file)?)
     } else {
         None
     };

--- a/llama-rs/src/util.rs
+++ b/llama-rs/src/util.rs
@@ -13,6 +13,7 @@ macro_rules! mulf {
     };
 }
 
+use memmap2::{Mmap, MmapAsRawDesc, MmapOptions};
 pub(crate) use mulf;
 use thiserror::Error;
 
@@ -173,4 +174,8 @@ mod tests {
         assert_eq!(buffer.push(&[0xE2, 0x82]).as_deref(), None);
         assert_eq!(buffer.push(&[0xAC]).as_deref(), Some("€"));
     }
+}
+
+pub fn mmap_populate<T: MmapAsRawDesc>(file: T) -> Result<Mmap, std::io::Error> {
+    unsafe { MmapOptions::new().populate().map(file) }
 }


### PR DESCRIPTION
Linux man page says about MAP_POPULATE


       MAP_POPULATE (since Linux 2.5.46)
              Populate (prefault) page tables for a mapping.  For a file
              mapping, this causes read-ahead on the  file.   This  will
              help  to reduce blocking on page faults later.  The mmap()
              call doesn't fail if the mapping cannot be populated  (for
              example,  due  to limitations on the number of mapped huge
              pages when using MAP_HUGETLB).  Support  for  MAP_POPULATE
              in  conjunction  with  private mappings was added in Linux
              2.6.23.

